### PR TITLE
Remove .desktop from app ID

### DIFF
--- a/data/com.github.tenderowl.turtle.appdata.xml.in
+++ b/data/com.github.tenderowl.turtle.appdata.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-    <id>com.github.tenderowl.turtle.desktop</id>
+    <id>com.github.tenderowl.turtle</id>
     <metadata_license>CC0-1.0</metadata_license>
     <project_license>MIT</project_license>
     <name>Turtle</name>


### PR DESCRIPTION
Not sure if this is causing the icon issues in AppCenter, but app IDs should not include `.desktop`